### PR TITLE
Add job cover image url to docs

### DIFF
--- a/source/includes/job_boards/_changelog.md.erb
+++ b/source/includes/job_boards/_changelog.md.erb
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2022-01-13
+Added `cover-image-url` field to [Webhook JSON object](#post-webhook), [XML feed](#xml-feed) and [Email](#email-with-job-data).
+
 ### 2021-12-28
 Added `employment-type` and `employment-level` fields to [Webhook JSON object](#post-webhook), [XML feed](#xml-feed) and [Email](#email-with-job-data).
 

--- a/source/includes/job_boards/_email.md.erb
+++ b/source/includes/job_boards/_email.md.erb
@@ -15,6 +15,7 @@ Employment type: none
 Employment level: none
 Job offer url: https://career.teamtailor.localhost/jobs/407c2b91-f06e-475f-9e51-72a62091abce
 Job apply url: https://career.teamtailor.localhost/jobs/407c2b91-f06e-475f-9e51-72a62091abce/applications/new?promotion=abc
+Cover image url: https://teamtailor-production.s3.eu-west-1.amazonaws.com/image_uploads/cd24c21b-db10-4cf2-aabd-4a6f4ef1cf06/original.png
 Price: 400 EUR
 
 Locations:

--- a/source/includes/job_boards/_webhooks.md.erb
+++ b/source/includes/job_boards/_webhooks.md.erb
@@ -176,6 +176,7 @@ POST ${BASE_URL}/webhook HTTP/1.1
     "employment-level": "none",
     "url": "https://career.teamtailor.localhost/jobs/23-marketing-coordinator",
     "apply-url": "https://career.teamtailor.localhost/jobs/23-marketing-coordinator/applications/new?promotion=2-monster-finland",
+    "cover-image-url": "https://example.com/original.jpg",
     "pitch": "Coadunatio centum animi. Succedo adversus inventore. Rem est uberrime.",
     "start-date": "2021-03-24T00:00:00+01:00",
     "end-date": "2021-03-31T00:00:00+02:00",
@@ -261,6 +262,7 @@ employment-type         | Employment type. One of following: **none**, **fully**
 employment-level        | Employment level. One of following: **none**, **senior**, **mid**, **professionals**, **technicians**, **sales**, **administrative**, **support**, **craft**, **operatives**, **laborers**, **service**
 url                     | URL to the job ad in Teamtailor
 apply-url               | URL to the job apply form in Teamtailor
+cover-image-url         | URL to the job cover image
 pitch                   | Pitch text about the job
 start-date              | Date from when the job ad is published
 end-date                | Date when job ad will be unlisted

--- a/source/includes/job_boards/_xml_feeds.md.erb
+++ b/source/includes/job_boards/_xml_feeds.md.erb
@@ -74,6 +74,9 @@ If you choose the Always included or Premium XML feed integration, you will rece
     <applyurl>
       <![CDATA[ https://career.teamtailor.localhost/jobs/23-marketing-coordinator/applications/new ]]>
     </applyurl>
+    <coverimageurl>
+      <![CDATA[ https://teamtailor-production.s3.eu-west-1.amazonaws.com/image_uploads/cd24c21b-db10-4cf2-aabd-4a6f4ef1cf06/original.png ]]>
+    </coverimageurl>
     <pitch>
       <![CDATA[ Coadunatio centum animi. Succedo adversus inventore. Rem est uberrime. ]]>
     </pitch>
@@ -166,10 +169,11 @@ startdate               | Date from when the job ad is published
 enddate                 | Date when job ad will be unlisted
 createddate             | Date when job ad was created
 remotestatus            | Remote status. One of following: **none**, **temporary**, **hybrid**, **fully**
-employmenttype         | Employment type. One of following: **none**, **fully**, **part**, **contract**, **temporary**, **apprenticeship**, **internship**, **volunteer**
-employmentlevel        | Employment level. One of following: **none**, **senior**, **mid**, **professionals**, **technicians**, **sales**, **administrative**, **support**, **craft**, **operatives**, **laborers**, **service**
+employmenttype          | Employment type. One of following: **none**, **fully**, **part**, **contract**, **temporary**, **apprenticeship**, **internship**, **volunteer**
+employmentlevel         | Employment level. One of following: **none**, **senior**, **mid**, **professionals**, **technicians**, **sales**, **administrative**, **support**, **craft**, **operatives**, **laborers**, **service**
 url                     | URL to the job ad in Teamtailor
 applyurl                | URL to the apply form in Teamtailor
+coverimageurl           | URL to the job cover image
 pitch                   | Pitch text about the job
 applybuttontext         | Text displayed on "apply" button
 locations               | Locations of the job. Implement many *location* elements


### PR DESCRIPTION
Adding a job cover image url. Connected with https://github.com/Teamtailor/teamtailor/pull/16895