### PR TITLE
Fix assessment criteria typo

### DIFF
--- a/source/includes/partners/partner_results/_index.md.erb
+++ b/source/includes/partners/partner_results/_index.md.erb
@@ -61,7 +61,7 @@ url              | string  | URL for viewing a report on your website.
 candidate-id     | string  | __Immutable__ UUID identifier for candidate.
 job-id           | number  | ID of the job webhook was sent from.
 attachments	 | list	   | List of attachment objects containing keys: __"url"__ and __"description"__.
-assessmnet-criteria	 | list	   | List of assessment criteria objects containing keys: __“id”__ and __“score”__ (optional)
+assessment-criteria	 | list	   | List of assessment criteria objects containing keys: __“id”__ and __“score”__ (optional)
 
 
 #### Assessment object

--- a/source/includes/partners/partner_results/_index.md.erb
+++ b/source/includes/partners/partner_results/_index.md.erb
@@ -61,7 +61,7 @@ url              | string  | URL for viewing a report on your website.
 candidate-id     | string  | __Immutable__ UUID identifier for candidate.
 job-id           | number  | ID of the job webhook was sent from.
 attachments	 | list	   | List of attachment objects containing keys: __"url"__ and __"description"__.
-assessment-criteria	 | list	   | List of assessment criteria objects containing keys: __“id”__ and __“score”__ (optional)
+assessment-criteria	 | list	   | List of assessment criteria objects containing keys: __"id"__ and __"score"__ (optional)
 
 
 #### Assessment object


### PR DESCRIPTION
There was a typo in the Partner API documentation, where `assessment-criteria` was misspelled in the list of attributes for the Partner result object: https://partner.teamtailor.com/partners/#partner-results.

The description of that attribute also used "fancy" quotes around key names, this changes that to straight double quotes to be consistent with the rest of the documentation.