### PR TITLE
Fix: Typos in API documentation

### DIFF
--- a/source/includes/job_boards/_webhooks.md.erb
+++ b/source/includes/job_boards/_webhooks.md.erb
@@ -247,7 +247,7 @@ reference-id            | Unique identifier of job ad in Teamtailor
 created-at              | Date when job ad was created
 duration                | Duration of job ad. In days
 job-board-id            | Unique identifier of job board in Teamtailor
-webhook-data            | Object containg picked options by user
+webhook-data            | Object containing picked options by user
 location                | Location of the job ad. User can optionally select it during purchasing the job ad. Implements location object
 company                 | Company that job belongs to. Implements company object
 job                     | Job data. Implements job object

--- a/source/includes/job_boards/_xml_feeds.md.erb
+++ b/source/includes/job_boards/_xml_feeds.md.erb
@@ -2,7 +2,7 @@
 
 If you choose the Always included or Premium XML feed integration, you will receive a unique url to the XML feed.
 
-Salary field is optiona
+Salary field is optional
 
 > Example XML feed
 
@@ -217,8 +217,8 @@ Attribute               | Value
 -------------------     | -------
 publisher               | Name of publisher of the feed
 publisherurl            | Url to feed publisher's website 
-lastupdatedat           | Timestamp of when the feed was last time updated. It's updated 3 times a days
-job                     | Node containg all the job ad data
+lastupdatedat           | Timestamp of when the feed was last time updated. It's updated 3 times a day
+job                     | Node containing all the job ad data
 company                 | Company name
 companydescription      | Description of the company
 companyuuid             | Company’s uuid


### PR DESCRIPTION
Fix for some typos in documentation
[Notion card](https://www.notion.so/teamtailor/Typos-in-API-documentation-12f885a70ca180a88996e0047e3ca5b1?pvs=4)