### PR TITLE
Improvement: Webhook payload syntax highlighting

### DIFF
--- a/source/includes/partners/_webhooks.md.erb
+++ b/source/includes/partners/_webhooks.md.erb
@@ -9,7 +9,11 @@ When a trigger is executed in Teamtailor, the webhook JSON object is sent to you
 ```http
 POST ${BASE_URL}/webhook HTTP/1.1
 Authorization: Bearer xxx-provider-key
+```
 
+> Expected payload
+
+```json
 {
   "partner-event": {
     "id": "f3d7e8e2-da33-4c10-ae5f-0e7f4d46f6d7",
@@ -54,7 +58,7 @@ Authorization: Bearer xxx-provider-key
           "name": "John Doe",
           "email": "john@example.com"
         }
-      ], 
+      ],
       "onboardings": [
         {
           "id": 177,
@@ -82,7 +86,7 @@ Authorization: Bearer xxx-provider-key
               "type": "boolean"
             }
           }
-        ]
+        ],
         "status": {
           "rejected": false
         },
@@ -114,13 +118,13 @@ Authorization: Bearer xxx-provider-key
           "has-driver-license": {
             "value": true,
             "type": "boolean"
-          },
+          }
         },
         {
-          "social-security-number": { 
-            "value": "123456-7890", 
+          "social-security-number": {
+            "value": "123456-7890",
             "type": "text"
-          },
+          }
         }
       ]
     },


### PR DESCRIPTION
Due to the lack of split between request and payload json there was no json highlighting to the webhook payload section.
I also fixed some commas and spaces because formatting had shown that it was incorrect.

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/d3c52df0-4929-463c-842c-baf4e4ebfb33) | ![image](https://github.com/user-attachments/assets/2658513b-faf8-4a8d-b41b-9a8aa643b168) |