### PR TITLE
Expand information about `infobox` in webhook config

### DIFF
--- a/source/includes/partners/webhook_config/_index.md.erb
+++ b/source/includes/partners/webhook_config/_index.md.erb
@@ -130,13 +130,25 @@ When using the `file` type, we upload the files to a private folder on S3, and s
 This URL is valid for 24 hours, so make sure to download the file when the webhook is sent to you.
 
 #### Infobox
-Renders a box with the icon of following types: 'info', 'error', 'warning', 'success', 'default'
+Renders a box with styling based on one of the following types: 'info', 'error', 'warning', 'success', 'default'
 
 ```json
 {
   "type": "infobox",
   "content": "To get information how to activate this integration works please <a href="">CLICK</a>",
   "icon": "info"
+}
+```
+
+By providing an attribute `required` it is possible to block a trigger from being configured:
+
+
+```json
+{
+  "type": "infobox",
+  "content": "Trigger cannot be configured at this time",
+  "icon": "error",
+  "required": true
 }
 ```
 


### PR DESCRIPTION
I was doing a lot of testing w.r.t. displaying errors when things have not been fully configured on a customer’s account on our end. I noticed:

1. it seems like the infoboxes no longer use icons (I think they did before?) and only apply styling. E.g. `bg-warning` and `bg-danger` classess.
2. it is possible to use infoboxes as a replacement for the `error` type field by making sure `required` is set to `true`. Doing that will disable the “Add trigger” button. This way some messages can use warning styling but still block the end-user from creating the trigger in their job.