### PR TITLE
Change email to techpartnership instead of partnership

### DIFF
--- a/source/includes/job_boards/_intro.md.erb
+++ b/source/includes/job_boards/_intro.md.erb
@@ -9,4 +9,4 @@
 * Integrate your job board with Teamtailor using HTTP Webhooks, XML Feed or in other way
 * Update resources created by your job board system
 
-If you are interested in integrating with us, check below options and contact us at [partnerships@teamtailor.com](mailto:partnerships@teamtailor.com).
+If you are interested in integrating with us, check below options and contact us at [techpartnerships@teamtailor.com](mailto:techpartnerships@teamtailor.com).

--- a/source/includes/partners/_intro.md.erb
+++ b/source/includes/partners/_intro.md.erb
@@ -1,13 +1,13 @@
 # Teamtailor Partner API
 
-If you have any question or feedback please contact us at [partnerships@teamtailor.com](mailto:partnerships@teamtailor.com)
+If you have any question or feedback please contact us at [techpartnerships@teamtailor.com](mailto:techpartnerships@teamtailor.com)
 
 ### Example use cases of this API:
 
 * Retrieve webhooks with candidate data when triggers are executed in Teamtailor.
 * Update assessment results for candidates.
 
-To set up new clients to use the webhook API, contact [partnerships@teamtailor.com](mailto:partnerships@teamtailor.com)
+To set up new clients to use the webhook API, contact [techpartnerships@teamtailor.com](mailto:techpartnerships@teamtailor.com)
 
 If your integration will need to utilize the Public Teamtailor API of the company
 We can change the setting of your partner to require this company token.


### PR DESCRIPTION
Got a request of changing the email to contact the partnership team on technical questions.