### PR TITLE
Fix: Added missing `uploads` and `resume` docs for `candidate` object

### DIFF
--- a/source/includes/partners/_webhooks.md.erb
+++ b/source/includes/partners/_webhooks.md.erb
@@ -137,14 +137,24 @@ Authorization: Bearer xxx-provider-key
             "type": "text"
           }
         }
-      ]
-    },
-    "company": {
-      "uuid": "vAXspNm0J2Y",
-      "name": "Teamtailor",
-      "url": "https://career.teamtailor.com",
-      "logotype": "https://res.cloudinary.com/teamtailor/image/upload/c_limit,f_auto,h_100,q_auto,w_100,dpr_2.0/v1433344861/b2urpbafegvjzexula0n"
+      ],
+      "uploads": [
+        {
+          "file-name": "example-document.pdf",
+          "url": "https://example.com/example-document.pdf"
+        }
+      ],
+      "resume": {
+        "file-name": "example-cv.pdf",
+        "url": "https://example.com/example-cv.pdf"
+      }
     }
+  },
+  "company": {
+    "uuid": "vAXspNm0J2Y",
+    "name": "Teamtailor",
+    "url": "https://career.teamtailor.com",
+    "logotype": "https://res.cloudinary.com/teamtailor/image/upload/c_limit,f_auto,h_100,q_auto,w_100,dpr_2.0/v1433344861/b2urpbafegvjzexula0n"
   }
 }
 ```
@@ -174,6 +184,8 @@ candidate.custom-fields | Candidate custom fields, list with: `type`, `value`. S
 candidate.job-offers    | Candidate job offers, list with: `id`, `created_at`, `salary` (contains `amount`, `currency`, `salary_time_unit`), `status`, `response`, `message`, `name`, `answered_at`, `start_date`. </br> **Note:** Job offers are only available to partners with "Include job offers" option enabled. To enable this option, please contact us directly.
 candidate.referrals     | Candidate referrals, list with `id`, `name`, `email`
 candidate.onboardings   | Candidate onboardings, list with: `id`, `status`, `progress`, `created_at`, `start_date`, `departament`, `role`, `job`, `user`. <br> **Note:** It will be only included if you use the Onboarding feature.
+candidate.uploads       | Candidate uploads, list with: `file-name`, `url`.
+candidate.resume        | Candidate resume, object with: `file-name`, `url`.
 
 ### Error handling
 


### PR DESCRIPTION
# 📝 Description 

"Something that is not mentioned in the partner documentation is that since last year we can add uploads to the webhook payload. This is something that we in support missed as well and have always advised to use Public API to fetch those."

# 🏁 Definition of Done

Closes https://github.com/Teamtailor/teamtailor/issues/39074