### PR TITLE
Feature: Direct Apply referer

### DIFF
--- a/source/includes/job_boards/direct_apply/_index.md.erb
+++ b/source/includes/job_boards/direct_apply/_index.md.erb
@@ -267,9 +267,9 @@ required         | boolean | Indicates if consent is required
 text             | string  | Human readable label
 url              | string  | Url to consent page. Present only for **privacy_policy** consent
 
-## POST apply
+## POST Apply
 
-Get the job data needed to configure apply form in your system.
+Send candidate data to Teamtailor. This creates the job application.
 
 ```http
 POST ${BASE_URL}/apply HTTP/1.1


### PR DESCRIPTION
## Description
We support `referer-id` in Direct Apply API.
Besides that I updated `/apply` description because it wasn't accurate.