### PR TITLE
Fix: Mentioned the Integrations Hub for getting Signing Key

### DIFF
--- a/source/includes/job_boards/_webhooks.md.erb
+++ b/source/includes/job_boards/_webhooks.md.erb
@@ -392,4 +392,5 @@ It is a JWT `Bearer` token placed in `Authorization` header, encoded using **HS2
 
 In order to decode it and get the secrets, you will need a signing key.
 You can find it in your Teamtailor account in the **Settings** > **Integrations** > **Integrations Hub** section.
+Search for your integration and click on **Details**. The **API Key** is the signing key.
 Should you need help, please contact us at [integrations@teamtailor.com](mailto:integrations@teamtailor.com).

--- a/source/includes/job_boards/_webhooks.md.erb
+++ b/source/includes/job_boards/_webhooks.md.erb
@@ -391,4 +391,5 @@ If you require secrets from user, e.g. API key or password, we will include it i
 It is a JWT `Bearer` token placed in `Authorization` header, encoded using **HS256** signing algorithm.
 
 In order to decode it and get the secrets, you will need a signing key.
-We will provide it to you if you ask us at [integrations@teamtailor.com](mailto:integrations@teamtailor.com).
+You can find it in your Teamtailor account in the **Settings** > **Integrations** > **Integrations Hub** section.
+Should you need help, please contact us at [integrations@teamtailor.com](mailto:integrations@teamtailor.com).


### PR DESCRIPTION
# Description

We've received questions about the signing key and it turned out customers are able to get them themselves. This PR adds description of user journey in order to get the signing key.