### PR TITLE
Docs: add ap stack

### DIFF
--- a/source/includes/partners/_changelog.md.erb
+++ b/source/includes/partners/_changelog.md.erb
@@ -1,4 +1,7 @@
 # Changelog
+### 2026-05-11
+Added AP (Asia-Pacific) stack base URL `api.au.teamtailor.com` to the Partner API base URLs table.
+
 ### 2026-04-08
 Removed mention of webhook retry mechanism from error handling docs — failed deliveries are not retried.
 

--- a/source/includes/partners/_intro.md.erb
+++ b/source/includes/partners/_intro.md.erb
@@ -21,3 +21,4 @@ Stack  | Teamtailor Partner API Base URL
 -------|------------------------------------------------
 EU     | api.teamtailor.com
 NA     | api.na.teamtailor.com
+AP     | api.au.teamtailor.com


### PR DESCRIPTION
Added Asia-Pacific stack base URL `api.au.teamtailor.com` to the Partner API base URLs table