### PR TITLE
Add validation endpoint section to job_boards

### DIFF
--- a/source/includes/job_boards/webhook_activation_config/_index.md.erb
+++ b/source/includes/job_boards/webhook_activation_config/_index.md.erb
@@ -168,3 +168,32 @@ Content-Type: application/vnd.api+json
   }
 }
 ```
+
+## Validation endpoint
+
+If you would like to validate the activation of your user, you are able to include in your activation config
+
+```json
+{
+   "config":{
+      "fields":[
+         {
+            "id":"api_key",
+            "type":"text",
+            "label":"Enter your api key"
+         }
+      ],
+      "validateEndpoint": "my-validation/validate"
+   }
+}
+```
+
+We will make the following request: `GET ${BASE_URL}/my-validation/validate` You can validate Authorization header and make a response
+
+You can response with 200, in this case user will see that validation was successful
+If you will render error http status (>=400) we will render your response
+
+The error response should be in format of an object with property 'errors' and array of strings as a value
+```json
+  {errors: ["String1", "String2"]}
+```


### PR DESCRIPTION
Activation config validation for channel was added in this [notion card](https://www.notion.so/teamtailor/Activation-config-validation-for-channel-334885a70ca1801ab74ff65c863b40be?source=copy_link)
this PR updates docs accordingly